### PR TITLE
Change && (and) to || (or) operators to check extensions

### DIFF
--- a/index.html
+++ b/index.html
@@ -93,7 +93,7 @@
 			if(fileTypes.length === 1) {
 				addFile = `if(${Path}.extension(fullPath) == "${fileTypes[0]}") {\n\t\t\t\tresult.push(fullPath);\n\t\t\t}`;
 			} else if(fileTypes.length > 1 && fileTypes.length <= 5) {
-				addFile = `final ext = ${Path}.extension(fullPath);\n\t\t\tif(\n\t\t\t\t${fileTypes.map(f => `ext == "${f}"`).join(" &&\n\t\t\t\t")}\n\t\t\t) {\n\t\t\t\tresult.push(fullPath);\n\t\t\t}`;
+				addFile = `final ext = ${Path}.extension(fullPath);\n\t\t\tif(\n\t\t\t\t${fileTypes.map(f => `ext == "${f}"`).join(" ||\n\t\t\t\t")}\n\t\t\t) {\n\t\t\t\tresult.push(fullPath);\n\t\t\t}`;
 			} else if(fileTypes.length > 5) {
 				addFile = `static final exts = [\n\t\t\t\t${fileTypes.map((f, i) => `${i % 5 === 4 ? "\n\t\t\t\t" : ""}"${f}"`).join(", ")}\n\t\t\t];\n\t\t\tif(exts.contains(${Path}.extension(fullPath)) {\n\t\t\t\tresult.push(fullPath);\n\t\t\t}`;
 			}


### PR DESCRIPTION
Makes multiple extensions work properly in the generated function